### PR TITLE
Fixed root redirect #205

### DIFF
--- a/exhibitor-standalone/src/main/java/com/netflix/exhibitor/servlet/ExhibitorServletFilter.java
+++ b/exhibitor-standalone/src/main/java/com/netflix/exhibitor/servlet/ExhibitorServletFilter.java
@@ -36,7 +36,7 @@ public class ExhibitorServletFilter implements Filter
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
     {
         HttpServletResponse httpServletResponse = (HttpServletResponse)response;
-        httpServletResponse.sendRedirect("/exhibitor/v1/ui/index.html");
+        httpServletResponse.sendRedirect("./exhibitor/v1/ui/index.html");
     }
 
     @Override


### PR DESCRIPTION
Fixes #205 - root redirect issue when Exhibitor is not installed as ROOT.war, but as a separate application, changed the absolute redirect in the default-redirect servlet filter to a relative one. Tested and the redirect works for both "/" and "/some-other-context/". The standalone uber jar doesn't redirect for "/" and that is existing behaviour(returns a 404).