### PR TITLE
Fixed redirect 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 =========================
 
 * Issue 231: Possible NPE due to not checking for null from usState.getUs()
+
 * Pull 239: Fixed Gradle uber JAR build
+
+* Pull 234: Fixed redirect in non-ROOT WARs. Also, FINALLY!, fix root redirect for standalone version.
+i.e. http://localhost:8080 will now redirect to http://localhost:8080/exhibitor/v1/ui/index.html
 
 1.5.4 - February 14, 2015
 =========================

--- a/exhibitor-standalone/src/main/java/com/netflix/exhibitor/application/ExhibitorMain.java
+++ b/exhibitor-standalone/src/main/java/com/netflix/exhibitor/application/ExhibitorMain.java
@@ -20,6 +20,7 @@ package com.netflix.exhibitor.application;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import com.netflix.exhibitor.servlet.ExhibitorServletFilter;
 import com.sun.jersey.spi.container.servlet.ServletContainer;
 import com.netflix.exhibitor.core.Exhibitor;
 import com.netflix.exhibitor.core.ExhibitorArguments;
@@ -36,6 +37,7 @@ import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter;
 import com.sun.jersey.api.client.filter.HTTPDigestAuthFilter;
 import com.sun.jersey.api.core.DefaultResourceConfig;
 import org.apache.curator.utils.CloseableUtils;
+import org.mortbay.jetty.Handler;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.handler.ContextHandler;
 import org.mortbay.jetty.security.HashUserRealm;
@@ -124,6 +126,7 @@ public class ExhibitorMain implements Closeable
         ServletContainer        container = new ServletContainer(application);
         server = new Server(httpPort);
         Context root = new Context(server, "/", Context.SESSIONS);
+        root.addFilter(ExhibitorServletFilter.class, "/", Handler.ALL);
         root.addServlet(new ServletHolder(container), "/*");
         if ( security != null )
         {

--- a/exhibitor-standalone/src/main/java/com/netflix/exhibitor/servlet/ExhibitorServletFilter.java
+++ b/exhibitor-standalone/src/main/java/com/netflix/exhibitor/servlet/ExhibitorServletFilter.java
@@ -36,7 +36,7 @@ public class ExhibitorServletFilter implements Filter
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
     {
         HttpServletResponse httpServletResponse = (HttpServletResponse)response;
-        httpServletResponse.sendRedirect("/exhibitor/v1/ui/index.html");
+        httpServletResponse.sendRedirect("exhibitor/v1/ui/index.html");
     }
 
     @Override


### PR DESCRIPTION
Fixed redirect in non-ROOT WARs. Also, FINALLY!, fix root redirect for standalone version. i.e. http://localhost:8080 will now redirect to http://localhost:8080/exhibitor/v1/ui/index.html