### PR TITLE
Added build.gradle with shadowJar for Exhibitor-standalone 1.5.5

### DIFF
--- a/exhibitor-standalone/shadowjar/build.gradle
+++ b/exhibitor-standalone/shadowjar/build.gradle
@@ -1,0 +1,43 @@
+buildscript {
+    repositories {
+        jcenter()
+        mavenCentral()
+    }
+    dependencies {
+      classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.1'
+    }
+}
+
+apply plugin: 'java'
+apply plugin: 'com.github.johnrengelman.shadow'
+
+group = 'exhibitor'
+archivesBaseName = 'exhibitor'
+version = '1.5.5'
+
+repositories {
+    jcenter()
+    mavenCentral()
+    maven {
+        url "https://repository.jboss.org/nexus/content/groups/public/"
+    }
+}
+
+dependencies {
+    compile 'com.netflix.exhibitor:exhibitor-standalone:1.5.5'
+}
+
+jar {
+    manifest {
+        attributes (
+            'Main-Class': 'com.netflix.exhibitor.application.ExhibitorMain',
+            'Implementation-Version': project.version
+        )
+    }
+}
+
+shadowJar {
+    mergeServiceFiles()
+}
+
+assemble.dependsOn shadowJar


### PR DESCRIPTION
Usage - `gradle shadowJar`