### PR TITLE
making the lock key separator in PseudoLockBase configurable

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/AutoManageLockArguments.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/AutoManageLockArguments.java
@@ -23,6 +23,7 @@ public class AutoManageLockArguments
     private final String prefix;
     private final int timeoutMs;
     private final int pollingMs;
+    private final String lockKeySeparator;
 
     public AutoManageLockArguments(String prefix)
     {
@@ -32,9 +33,15 @@ public class AutoManageLockArguments
 
     public AutoManageLockArguments(String prefix, int timeoutMs, int pollingMs)
     {
+        this(prefix, timeoutMs, pollingMs, PseudoLockBase.DEFAULT_LOCK_KEY_SEPARATOR);
+    }
+
+    public AutoManageLockArguments(String prefix, int timeoutMs, int pollingMs, String lockKeySeparator)
+    {
         this.prefix = prefix;
         this.timeoutMs = timeoutMs;
         this.pollingMs = pollingMs;
+        this.lockKeySeparator = lockKeySeparator;
     }
 
     public String getPrefix()
@@ -50,5 +57,10 @@ public class AutoManageLockArguments
     public int getPollingMs()
     {
         return pollingMs;
+    }
+
+    public String getLockKeySeparator()
+    {
+        return lockKeySeparator;
     }
 }

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/filesystem/FileSystemPseudoLock.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/filesystem/FileSystemPseudoLock.java
@@ -43,6 +43,12 @@ public class FileSystemPseudoLock extends PseudoLockBase
         this.directory = directory;
     }
 
+    public FileSystemPseudoLock(File directory, String prefix, int timeoutMs, int pollingMs, int settlingMs, String lockKeySeparator)
+    {
+        super(prefix, timeoutMs, pollingMs, settlingMs, lockKeySeparator);
+        this.directory = directory;
+    }
+
     @Override
     protected void createFile(String key, byte[] contents) throws Exception
     {

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/s3/S3ConfigAutoManageLockArguments.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/s3/S3ConfigAutoManageLockArguments.java
@@ -35,8 +35,15 @@ public class S3ConfigAutoManageLockArguments extends AutoManageLockArguments
         this.settlingMs = settlingMs;
     }
 
+    public S3ConfigAutoManageLockArguments(String prefix, int timeoutMs, int pollingMs, int settlingMs, String separator)
+    {
+        super(prefix, timeoutMs, pollingMs, separator);
+        this.settlingMs = settlingMs;
+    }
+
     public int getSettlingMs()
     {
         return settlingMs;
     }
+
 }

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/s3/S3ConfigProvider.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/s3/S3ConfigProvider.java
@@ -165,7 +165,8 @@ public class S3ConfigProvider implements ConfigProvider
             arguments.getLockArguments().getPrefix(),
             arguments.getLockArguments().getTimeoutMs(),
             arguments.getLockArguments().getPollingMs(),
-            arguments.getLockArguments().getSettlingMs()
+            arguments.getLockArguments().getSettlingMs(),
+            arguments.getLockArguments().getLockKeySeparator()
         );
     }
 

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/s3/S3PseudoLock.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/s3/S3PseudoLock.java
@@ -63,6 +63,23 @@ public class S3PseudoLock extends PseudoLockBase
         this.bucket = bucket;
     }
 
+
+    /**
+     * @param client the S3 client
+     * @param bucket the S3 bucket
+     * @param lockPrefix key prefix
+     * @param timeoutMs max age for locks
+     * @param pollingMs how often to poll S3
+     * @param settlingMs how long to wait for S3 to reach consistency
+     * @param lockKeySeparator the separator to use for the lock key
+     */
+    public S3PseudoLock(S3Client client, String bucket, String lockPrefix, int timeoutMs, int pollingMs, int settlingMs, String lockKeySeparator)
+    {
+        super(lockPrefix, timeoutMs, pollingMs, settlingMs, lockKeySeparator);
+        this.client = client;
+        this.bucket = bucket;
+    }
+
     @Override
     protected void createFile(String key, byte[] contents) throws Exception
     {

--- a/exhibitor-core/src/test/java/com/netflix/exhibitor/core/config/s3/TestS3PseudoLock.java
+++ b/exhibitor-core/src/test/java/com/netflix/exhibitor/core/config/s3/TestS3PseudoLock.java
@@ -150,4 +150,15 @@ public class TestS3PseudoLock
         Assert.assertTrue(lock.lock(mockLog, 5, TimeUnit.SECONDS));
         lock.unlock();
     }
+
+    @Test
+    public void         testWithDifferentLockKeySeparator() throws Exception
+    {
+        MockS3Client        client = new MockS3Client();
+        ActivityLog         mockLog = Mockito.mock(ActivityLog.class);
+
+        S3PseudoLock        lock = new S3PseudoLock(client, "foo", "bar", 10000, 1, 0, "#");
+        Assert.assertTrue(lock.lock(mockLog, 5, TimeUnit.SECONDS));
+        lock.unlock();
+    }
 }


### PR DESCRIPTION
This is useful for places where cluster names needs to include the "_" char (e.g. to interface with other automation systems).