### PR TITLE
Fix JSON config integer parsing (issue #184)

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/rest/ConfigResource.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/rest/ConfigResource.java
@@ -308,15 +308,7 @@ public class ConfigResource
                 {
                     return 0;
                 }
-                try
-                {
-                    return Integer.parseInt(node.getTextValue());
-                }
-                catch ( NumberFormatException e )
-                {
-                    // ignore
-                }
-                return 0;
+                return node.getValueAsInt();
             }
         };
     }


### PR DESCRIPTION
The config/set REST API currently only works if you pass the integers as strings. This means even just copying / pasting the configuration from config/get-state doesn't work.

The configure resource attempts to parse integer values using `JsonNode.getTextValue`, but this returns null when the value isn't a string. `JsonNode.getValueAsInt` does exactly what we want it to do: If the value is an integer, it returns the integer. If it's a string, it attempts to parse an integer out of the string value, and if that fails, it returns zero.

This resolves https://github.com/Netflix/exhibitor/issues/184