### PR TITLE
Changed method used to get the hostname

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/Exhibitor.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/Exhibitor.java
@@ -104,7 +104,7 @@ public class Exhibitor implements Closeable
         String      host = "unknown";
         try
         {
-            return InetAddress.getLocalHost().getHostName();
+            return InetAddress.getLocalHost().getCanonicalHostName();
         }
         catch ( UnknownHostException e )
         {


### PR DESCRIPTION
It seems like using FQDNs is a better idea for the configs.

Let me know what you think.